### PR TITLE
load URL if output begins with Location:

### DIFF
--- a/ScriptExec/ScriptExecController.m
+++ b/ScriptExec/ScriptExecController.m
@@ -949,10 +949,10 @@
     
     // if web output, we continually re-render to accomodate incoming data, else we scroll down
     if (outputType == PLATYPUS_WEBVIEW_OUTPUT) {
-        NSArray *lines = [NSMutableArray arrayWithArray: [[text string] componentsSeparatedByString: @"\n"]];
-        if ([lines count] == 0 && [[outputTextView string] hasPrefix: @"Location: "]) {
-            NSString *url = [[lines objectAtIndex: 0] substringFromIndex: 10];
-            [webOutputWebView takeStringURLFrom: url];
+        NSArray *lines = [NSArray arrayWithArray: [[text string] componentsSeparatedByString: @"\n"]];
+        if ([lines count] > 0 && [[lines objectAtIndex:1] hasPrefix: @"Location: "]) {
+            NSString *url = [[lines objectAtIndex: 1] substringFromIndex: 10];
+            [[webOutputWebView mainFrame] loadRequest: [NSURLRequest requestWithURL: [NSURL URLWithString: url]] ];
         }
         else {
             [[webOutputWebView mainFrame] loadHTMLString: [outputTextView string] baseURL: [NSURL fileURLWithPath: [[NSBundle mainBundle] resourcePath]] ];


### PR DESCRIPTION
as described in https://github.com/sveinbjornt/Platypus/issues/12 this should make the WebView load a URL if the script's first line of output begins with `Location:`. 
