### PR TITLE
Fix typo. Change "doucments" to "documents" in PrintHelp

### DIFF
--- a/CommandLineTool/platypus_command_line_tool.m
+++ b/CommandLineTool/platypus_command_line_tool.m
@@ -634,7 +634,7 @@ Options:\n\
    \n\
    -i [iconPath]        Set icon for application\n\
    -u [author]          Set name of application author\n\
-   -Q [iconPath]        Set icon for doucments\n\
+   -Q [iconPath]        Set icon for documents\n\
    -V [version]         Set version of application\n\
    -I [identifier]      Set bundle identifier (i.e. org.yourname.appname)\n\
    \n\


### PR DESCRIPTION
Tiniest contribution possible! Thanks for the great tool.
