### PR TITLE
"Show Shell Command" Menu Option Generates Invalid Command Line Switches

### DIFF
--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -736,10 +736,10 @@
     }
     
     // only set app name arg if we have a proper value
-    NSString *appNameArg = [[properties objectForKey: @"Name"] isEqualToString: @""] ? @"" : [NSString stringWithFormat: @" -a '%@'", [properties objectForKey: @"Name"]];
+    NSString *appNameArg = [[properties objectForKey: @"Name"] isEqualToString: @""] ? @"" : [NSString stringWithFormat: @" -a '%@' ", [properties objectForKey: @"Name"]];
     
     // only add identifier argument if it varies from default
-    NSString *identifArg = [NSString stringWithFormat: @" -I %@", [properties objectForKey: @"Identifier"]];
+    NSString *identifArg = [NSString stringWithFormat: @" -I %@ ", [properties objectForKey: @"Identifier"]];
     if ([[properties objectForKey: @"Identifier"] isEqualToString: [PlatypusAppSpec standardBundleIdForAppName: [properties objectForKey: @"Name"] usingDefaults: NO]])
         identifArg = @"";
     


### PR DESCRIPTION
I noticed that some options in the UI cause an invalid command line to be generated to form the "Show Shell Command" menu option. It appears that a few of the command were missing trailing spaces.

I have not compiled/tested this code, but the changes appear simple enough to warrant a pull request as-is.

![platypus options to create produce bug](https://f.cloud.github.com/assets/178680/89120/57b8d484-6520-11e2-9bf0-cc41404d605a.png)

![platypus invalid command line options](https://f.cloud.github.com/assets/178680/89119/57aa2fce-6520-11e2-81a5-7499514d7684.png)
