### PR TITLE
Add "DETAILS:SHOW" and "DETAILS:HIDE" progress bar commands

### DIFF
--- a/ScriptExec/ScriptExecController.h
+++ b/ScriptExec/ScriptExecController.h
@@ -155,6 +155,8 @@
 - (void)loadSettings;
 - (IBAction)cancel:(id)sender;
 - (IBAction)toggleDetails:(id)sender;
+- (IBAction)showDetails;
+- (IBAction)hideDetails;
 
 - (void)fatalAlert:(NSString *)message subText:(NSString *)subtext;
 @end

--- a/ScriptExec/ScriptExecController.m
+++ b/ScriptExec/ScriptExecController.m
@@ -896,6 +896,15 @@
                 [progressBarIndicator setIndeterminate:NO];
                 [progressBarIndicator setDoubleValue:[progressPercent doubleValue]];
             }
+            else if ([theLine hasPrefix:@"DETAILS:"]) {
+                NSString *detailsCommand = [theLine substringFromIndex:8];
+                if ([detailsCommand isEqualToString:@"SHOW"]) {
+                    [self showDetails];
+                }
+                else if ([detailsCommand isEqualToString:@"HIDE"]) {
+                    [self hideDetails];
+                }
+            }
             else {
                 [dropletMessageTextField setStringValue:theLine];
                 [progressBarMessageTextField setStringValue:theLine];
@@ -966,6 +975,20 @@
         winRect.origin.y -= 224;
         winRect.size.height += 224;
         [progressBarWindow setFrame:winRect display:TRUE animate:TRUE];
+    }
+}
+
+// show the details text field in progress bar output
+- (IBAction)showDetails {
+    if ([progressBarDetailsTriangle state] == NSOffState) {
+        [progressBarDetailsTriangle performClick:progressBarDetailsTriangle];
+    }
+}
+
+// hide the details text field in progress bar output
+- (IBAction)hideDetails {
+    if ([progressBarDetailsTriangle state] != NSOffState) {
+        [progressBarDetailsTriangle performClick:progressBarDetailsTriangle];
     }
 }
 


### PR DESCRIPTION
I added new commands for the Progress Bar interface to show and hide the Details pane of the interface.  The idea being that on an error, it might be nice to automatically show the details to the user.
