### PR TITLE
Use /usr/bin ibtool instead of xcode path

### DIFF
--- a/Common.h
+++ b/Common.h
@@ -75,7 +75,7 @@
 #define CMDLINE_ICON_PATH           @"/usr/local/share/platypus/PlatypusDefault.icns"
 #define CMDLINE_ARG_SEPARATOR       @"|"
 
-#define IBTOOL_PATH                 [NSString stringWithFormat:@"%@/Contents/Developer/usr/bin/ibtool", [WORKSPACE fullPathForApplication:@"Xcode"]]
+#define IBTOOL_PATH                 @"/usr/bin/ibtool"
 #define PERL_INTERPRETER_PATH       @"/usr/bin/perl"
 #define CODESIGN_PATH               @"/usr/bin/codesign"
 


### PR DESCRIPTION
On GitHub actions there are multiple versions of xcode installed at `/Applications/Xcode_x.y.z.app` and using `xcode-select` or `DEVELOPER_DIR` you select the version that should be active.

When using platypus in this environment after changing the xcode version you get the following error:

```
/usr/local/bin/platypus -DBR -x -y -i data/icon.icns -a Kivy -o None -p /bin/bash -V 2.0.0rc3 -I org.kivy.osxlauncher -X '*' data/script /Users/runner/work/kivy/kivy-sdk-packager/osx/Kivy.app
Creating application bundle folder hierarchy
Copying executable to bundle
Copying nib file to bundle
Optimizing nib file
2020-09-13 22:10:04.980 platypus[1637:12309] *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'launch path not accessible'
*** First throw call stack:
(
	0   CoreFoundation                      0x00007fff2d415727 __exceptionPreprocess + 250
	1   libobjc.A.dylib                     0x00007fff6635ba9e objc_exception_throw + 48
	2   Foundation                          0x00007fff2fafafdd -[NSConcreteTask launchWithDictionary:error:] + 5213
	3   platypus                            0x0000000105808a22 platypus + 72226
	4   platypus                            0x00000001058036d0 platypus + 50896
	5   platypus                            0x00000001057feb61 platypus + 31585
	6   libdyld.dylib                       0x00007fff674fbcc9 start + 1
)
libc++abi.dylib: terminating with uncaught exception of type NSException
./create-osx-bundle.sh: line 104:  1637 Abort trap: 6   
```

I fixed it by using the `/usr/bin/ibtool`, because that always links to the correct `ibtool`. I'm not very familiar with osx so I'm not sure if that is always available, but given that `CODESIGN_PATH` is similarly taken from `/usr/bin`, I expect this is safe.