### PR TITLE
Make key and order front the text window a little later, so it doesn't take several seconds to appear

### DIFF
--- a/ScriptExec/SEController.m
+++ b/ScriptExec/SEController.m
@@ -624,7 +624,6 @@ static const NSInteger detailsHeight = 224;
             
             // Prepare window
             [textWindow setTitle:appName];
-            [textWindow makeKeyAndOrderFront:self];
         }
             break;
             
@@ -730,6 +729,7 @@ static const NSInteger detailsHeight = 224;
                 [textWindowCancelButton setEnabled:NO];
             }
             [textWindowProgressIndicator startAnimation:self];
+            [textWindow makeKeyAndOrderFront:self];
         }
             break;
             


### PR DESCRIPTION
Without this change, my script output does not consistently appear for several seconds after the script completes.

This is on macOS 13.6.3 on a M1 Max MacBook Pro, if relevant.