### PR TITLE
Fix inconsistent image size when clicking NSPopUpButton

### DIFF
--- a/Application/PlatypusWindowController.m
+++ b/Application/PlatypusWindowController.m
@@ -1034,7 +1034,7 @@
 
 - (void)menuWillOpen:(NSMenu *)menu {
     if (menu == [interfaceTypePopupButton menu]) {
-        [self updateInterfaceTypeMenu:NSMakeSize(32, 32)];
+        [self updateInterfaceTypeMenu:NSMakeSize(16, 16)];
     }
 }
 


### PR DESCRIPTION
When clicking the NSPopUpButton, the image is resized to 32×32.
I’m not sure why this behavior was implemented originally, but it looks like a bug.
Before:
<img width="325" height="49" alt="image" src="https://github.com/user-attachments/assets/b7ad9cb5-1628-424d-b757-622ce0b05a61" />
After:
<img width="370" height="48" alt="image" src="https://github.com/user-attachments/assets/1f534685-6299-4859-acea-bdfcb8bfa5cb" />
