### PR TITLE
Allow user to override the temporary directory by setting the `TMPDIR` environment variable

### DIFF
--- a/Shared/NSFileManager+TempFiles.m
+++ b/Shared/NSFileManager+TempFiles.m
@@ -42,6 +42,7 @@
     
     NSString *tmpFileNameTemplate = fileName ? fileName : @"tmp_file_platypus_macos.XXXXXX";
     // Allow user to override the temporary directory by setting the TMPDIR environment variable
+    NSString *tmpDir = NSTemporaryDirectory();
     char *tmpdir_cstring = getenv("TMPDIR");
     if (tmpdir_cstring != NULL && strlen(tmpdir_cstring) > 0) {
       NSString *tmpDir = [NSString stringWithUTF8String:tmpdir_cstring];

--- a/Shared/NSFileManager+TempFiles.m
+++ b/Shared/NSFileManager+TempFiles.m
@@ -41,12 +41,17 @@
     // http://cocoawithlove.com/2009/07/temporary-files-and-folders-in-cocoa.html
     
     NSString *tmpFileNameTemplate = fileName ? fileName : @"tmp_file_platypus_macos.XXXXXX";
-    NSString *tmpDir = NSTemporaryDirectory();
-    if (!tmpDir) {
-        NSLog(@"NSTemporaryDirectory() returned nil");
-        return nil;
+    // Allow user to override the temporary directory by setting the TMPDIR environment variable
+    char *tmpdir_cstring = getenv("TMPDIR");
+    if (tmpdir_cstring != NULL && strlen(tmpdir_cstring) > 0) {
+      NSString *tmpDir = [NSString stringWithUTF8String:tmpdir_cstring];
+    } else {
+      if (!tmpDir) {
+          NSLog(@"NSTemporaryDirectory() returned nil");
+          return nil;
+      }
     }
-    
+
     NSString *tempFileTemplate = [tmpDir stringByAppendingPathComponent:tmpFileNameTemplate];
     const char *tempFileTemplateCString = [tempFileTemplate fileSystemRepresentation];
     char *tempFileNameCString = (char *)malloc(strlen(tempFileTemplateCString) + 1);

--- a/Shared/NSFileManager+TempFiles.m
+++ b/Shared/NSFileManager+TempFiles.m
@@ -45,7 +45,7 @@
     NSString *tmpDir = NSTemporaryDirectory();
     char *tmpdir_cstring = getenv("TMPDIR");
     if (tmpdir_cstring != NULL && strlen(tmpdir_cstring) > 0) {
-      NSString *tmpDir = [NSString stringWithUTF8String:tmpdir_cstring];
+      tmpDir = [NSString stringWithUTF8String:tmpdir_cstring];
     } else {
       if (!tmpDir) {
           NSLog(@"NSTemporaryDirectory() returned nil");

--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -261,11 +261,11 @@
     // Get temporary directory, make sure it's kosher. Apparently NSTemporaryDirectory() can return nil
     // See http://www.cocoadev.com/index.pl?NSTemporaryDirectory
     // Allow user to override the temporary directory by setting the TMPDIR environment variable
+    NSString *tmpPath = NSTemporaryDirectory();
     char *tmpdir_cstring = getenv("TMPDIR");
     if (tmpdir_cstring != NULL && strlen(tmpdir_cstring) > 0) {
-      NSString *tmpPath = [NSString stringWithUTF8String:tmpdir_cstring];
+      tmpPath = [NSString stringWithUTF8String:tmpdir_cstring];
     } else {
-      NSString *tmpPath = NSTemporaryDirectory();
       if (tmpPath == nil) {
         tmpPath = @"/tmp/"; // Fallback, just in case
       }

--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -260,11 +260,17 @@
     // .app bundle
     // Get temporary directory, make sure it's kosher. Apparently NSTemporaryDirectory() can return nil
     // See http://www.cocoadev.com/index.pl?NSTemporaryDirectory
-    NSString *tmpPath = NSTemporaryDirectory();
-    if (tmpPath == nil) {
+    // Allow user to override the temporary directory by setting the TMPDIR environment variable
+    char *tmpdir_cstring = getenv("TMPDIR");
+    if (tmpdir_cstring != NULL && strlen(tmpdir_cstring) > 0) {
+      NSString *tmpPath = [NSString stringWithUTF8String:tmpdir_cstring];
+    } else {
+      NSString *tmpPath = NSTemporaryDirectory();
+      if (tmpPath == nil) {
         tmpPath = @"/tmp/"; // Fallback, just in case
+      }
     }
-    
+
     // Make sure we can write to temp path
     if ([FILEMGR isWritableFileAtPath:tmpPath] == NO) {
         _error = [NSString stringWithFormat:@"Could not write to the temp directory '%@'.", tmpPath];


### PR DESCRIPTION
By default, Platypus will use `NSTemporaryDirectory()` to get the temp directory.

This PR allows the user to override the temp directory by setting the `TMPDIR` environment variable.

Motivation: I'd like to run Platypus inside a sandbox (specifically, the sandbox that Homebrew sets up when building and testing a formula). The sandbox disallows writes to the directory returned by `NSTemporaryDirectory()`. However, there are other directories that are writable. I'd like to be able to set the `TMPDIR` environment variable to a place that I know is writable, and have Platypus write to `TMPDIR` instead of `NSTemporaryDirectory()`.