### PR TITLE
In the "Error writing Info.plist" error message, including the path to which we failed to write

### DIFF
--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -415,7 +415,6 @@
                                                                  options:0
                                                                    error:nil];
     if (!infoData || ![infoData writeToFile:infoPlistPath atomically:YES]) {
-        // _error = @"Error writing Info.plist";
         _error = [NSString stringWithFormat:@"Error writing Info.plist: '%@'.", infoPlistPath];
         return NO;
     }

--- a/Shared/PlatypusAppSpec.m
+++ b/Shared/PlatypusAppSpec.m
@@ -415,7 +415,8 @@
                                                                  options:0
                                                                    error:nil];
     if (!infoData || ![infoData writeToFile:infoPlistPath atomically:YES]) {
-        _error = @"Error writing Info.plist";
+        // _error = @"Error writing Info.plist";
+        _error = [NSString stringWithFormat:@"Error writing Info.plist: '%@'.", infoPlistPath];
         return NO;
     }
     


### PR DESCRIPTION
I was finding myself hitting the "Error writing Info.plist" error message, and it was difficult for me to debug, until I added the value of `infoPlistPath` to the error message, which is what this PR does.